### PR TITLE
Create OrderStatuses collection with MongoDB migration

### DIFF
--- a/migrations/20220913101843-orderStatuses.js
+++ b/migrations/20220913101843-orderStatuses.js
@@ -1,0 +1,24 @@
+module.exports = {
+  async up (db) {
+    try {
+      await db.collection('orderstatuses').deleteMany({});
+      await db
+        .collection('orderstatuses')
+        .insertMany([
+          { name: 'In progress' },
+          { name: 'Resolved' },
+          { name: 'Rejected' }
+        ]);
+    } catch (error) {
+      console.error('Error with OrderStatuses Migration: ', error);
+    }
+  },
+
+  async down (db) {
+    try {
+      await db.collection('orderstatuses').deleteMany({});
+    } catch (error) {
+      console.error('Error with OrderStatuses Migration: ', error);
+    }
+  }
+};

--- a/migrations/tests/20220913101843-orderStatuses.test.js
+++ b/migrations/tests/20220913101843-orderStatuses.test.js
@@ -1,0 +1,51 @@
+const { up, down } = require('../20220913101843-orderStatuses');
+
+describe('20220913101843-orderStatuses migration tests', () => {
+  const deleteManyMock = jest.fn();
+  const insertManyMock = jest.fn();
+  const dbStub = {
+    collection: () => ({
+      deleteMany: deleteManyMock,
+      insertMany: insertManyMock
+    })
+  };
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should call deleteMany and insert many mocks while calling up method', async () => {
+    await up(dbStub);
+
+    expect(deleteManyMock).toHaveBeenCalled();
+    expect(insertManyMock).toHaveBeenCalled();
+  });
+
+  it('should call deleteMany mock while calling down method', async () => {
+    await down(dbStub);
+
+    expect(deleteManyMock).toHaveBeenCalled();
+  });
+
+  it('throws an error while connecting to db when calling up method and calls console.error method', async () => {
+    insertManyMock.mockImplementation(() => {
+      throw new Error();
+    });
+
+    console.error = jest.fn();
+    await up(dbStub);
+
+    expect(console.error).toHaveBeenCalled();
+  });
+
+  it('throws an error while connecting to db when calling down method and calls console.error method', async () => {
+    deleteManyMock.mockImplementation(() => {
+      throw new Error();
+    });
+
+    console.error = jest.fn();
+    await down(dbStub);
+
+    expect(console.error).toHaveBeenCalled();
+  });
+});

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -3,3 +3,4 @@ module.exports.UserStatuses = require('./userStatuses');
 module.exports.ProductStatuses = require('./productStatuses');
 module.exports.UserRoles = require('./userRoles');
 module.exports.Categories = require('./categories');
+module.exports.OrderStatuses = require('./orderStatuses');

--- a/src/models/orderStatuses.js
+++ b/src/models/orderStatuses.js
@@ -1,0 +1,7 @@
+const mongoose = require('mongoose');
+
+const orderStatusesSchema = new mongoose.Schema({
+  name: String
+});
+
+module.exports = mongoose.model('OrderStatuses', orderStatusesSchema);


### PR DESCRIPTION
Title: Create OrderStatuses collection with MongoDB migration

Description: 
> We need to:
> Create OrderStatuses Collection and MongoDB Migration for OrderStatuses
> So:
> We can use OrderStatuses Collection.

Ticket link: https://github.com/Sf-62-NodeJS/clothes-market-server/issues/49
